### PR TITLE
feat: support for role-based grants on Snowflake pipes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,9 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-## [2.0.0](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-pipe/compare/v1.0.0...v2.0.0) (2026-02-20)
-
-### ⚠ BREAKING CHANGES
-
-* Complete module restructure from Snowflake warehouse to pipe
-
-- Replace snowflake_warehouse resource with snowflake_pipe resource
-- Convert to single-module repository layout (removed modules/ directory)
-- Update Snowflake provider to snowflakedb/snowflake >= 1.0.0
-- Add pipe-specific configuration: database, schema, copy_statement, auto_ingest
-- Support AWS SNS topic, error integration, and storage integration
-- Update examples: single-pipe and multiple-pipes
-- Update Terratest integration tests for pipe resources
-- Add header comments to all Terraform configuration files
-
-### Features
-
-* convert warehouse module to pipe module with single-module layout ([713bd48](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-pipe/commit/713bd4831ab2be86035829919861b4881aeea04b))
-
-### Bug Fixes
-
-* enable snowflake_pipe preview feature in examples ([5ba63cd](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-pipe/commit/5ba63cd96745accfa196abb93c6e55f5f7b4812a))
-
 ## [unreleased]
+
+### 🚀 Features
+
+- Add optional grants attribute for role-based pipe permissions
+## [2.0.0] - 2026-02-20
 
 ### 🚀 Features
 
@@ -40,6 +18,11 @@ All notable changes to this project will be documented in this file.
 - Update CHANGELOG.md [skip ci]
 - Update CHANGELOG.md [skip ci]
 - Update Snowflake provider version and pipe configuration
+- Update CHANGELOG.md [skip ci]
+
+### ⚙️ Miscellaneous Tasks
+
+- *(release)* Version 2.0.0 [skip ci]
 ## [1.0.0] - 2026-02-09
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Terraform module for creating and managing Snowflake pipes using a map of conf
 - Outputs keyed by pipe identifier for easy reference
 - Support for auto-ingest with AWS SNS or storage integration
 - Support for error integration configuration
+- Support for role-based grants on pipes
 
 ## Usage
 
@@ -94,6 +95,35 @@ module "pipe" {
 }
 ```
 
+### Pipe with Role Grants
+
+```hcl
+module "pipe" {
+  source = "github.com/subhamay-bhattacharyya-tf/terraform-snowflake-pipe"
+
+  pipe_configs = {
+    "my_pipe" = {
+      database       = "MY_DATABASE"
+      schema         = "MY_SCHEMA"
+      name           = "MY_PIPE"
+      copy_statement = "COPY INTO MY_DATABASE.MY_SCHEMA.MY_TABLE FROM @MY_DATABASE.MY_SCHEMA.MY_STAGE"
+      auto_ingest    = false
+      comment        = "Pipe with role grants"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["MONITOR", "OPERATE"]
+        },
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["MONITOR"]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Examples
 
 - [Single Pipe](examples/single-pipe) - Create a single pipe
@@ -131,6 +161,19 @@ module "pipe" {
 | error_integration | string | null | Name of the notification integration for error notifications |
 | integration | string | null | Name of the storage integration for auto-ingest |
 | comment | string | null | Description of the pipe |
+| grants | list(object) | [] | List of role grants for the pipe |
+
+### grants Object Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| role_name | string | Name of the role to grant privileges to |
+| privileges | list(string) | List of privileges to grant (e.g., MONITOR, OPERATE) |
+
+### Valid Pipe Privileges
+
+- MONITOR - View pipe status and history
+- OPERATE - Start, stop, and refresh the pipe
 
 ## Outputs
 
@@ -141,6 +184,7 @@ module "pipe" {
 | pipe_notification_channels | Map of notification channels for SNS integration |
 | pipe_owners | Map of pipe owners |
 | pipes | All pipe resources |
+| pipe_grants | All pipe grant resources |
 
 ## Validation
 

--- a/examples/multiple-pipes/README.md
+++ b/examples/multiple-pipes/README.md
@@ -24,6 +24,12 @@ module "pipes" {
       copy_statement = "COPY INTO ANALYTICS_DB.RAW.CUSTOMERS FROM @ANALYTICS_DB.RAW.S3_STAGE/customers/"
       auto_ingest    = false
       comment        = "Pipe for loading customer data from S3"
+      grants = [
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["MONITOR"]
+        }
+      ]
     }
     "events_pipe" = {
       database          = "ANALYTICS_DB"
@@ -33,6 +39,12 @@ module "pipes" {
       auto_ingest       = true
       aws_sns_topic_arn = "arn:aws:sns:us-east-1:123456789012:snowflake-events"
       comment           = "Pipe for auto-ingesting event data from S3"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["MONITOR", "OPERATE"]
+        }
+      ]
     }
   }
 }
@@ -87,6 +99,14 @@ provider "snowflake" {
 | error_integration | string | null | Name of the notification integration for error notifications |
 | integration | string | null | Name of the storage integration for auto-ingest |
 | comment | string | null | Description of the pipe |
+| grants | list(object) | [] | List of role grants for the pipe |
+
+### grants Object Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| role_name | string | Name of the role to grant privileges to |
+| privileges | list(string) | List of privileges to grant (MONITOR, OPERATE) |
 
 ## Outputs
 
@@ -97,6 +117,7 @@ provider "snowflake" {
 | pipe_notification_channels | The notification channels for the pipes |
 | pipe_owners | The owners of the pipes |
 | pipes | All pipe resources |
+| pipe_grants | All pipe grant resources |
 
 ## Running This Example
 

--- a/examples/multiple-pipes/variables.tf
+++ b/examples/multiple-pipes/variables.tf
@@ -17,6 +17,10 @@ variable "pipe_configs" {
     error_integration = optional(string, null)
     integration       = optional(string, null)
     comment           = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {
     "orders_pipe" = {

--- a/examples/single-pipe/README.md
+++ b/examples/single-pipe/README.md
@@ -21,6 +21,31 @@ module "pipe" {
 }
 ```
 
+### With Role Grants
+
+```hcl
+module "pipe" {
+  source = "github.com/subhamay-bhattacharyya-tf/terraform-snowflake-pipe"
+
+  pipe_configs = {
+    "my_pipe" = {
+      database       = "MY_DATABASE"
+      schema         = "MY_SCHEMA"
+      name           = "MY_PIPE"
+      copy_statement = "COPY INTO MY_DATABASE.MY_SCHEMA.MY_TABLE FROM @MY_DATABASE.MY_SCHEMA.MY_STAGE"
+      auto_ingest    = false
+      comment        = "My test pipe with grants"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["MONITOR", "OPERATE"]
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Requirements
 
 | Name | Version |
@@ -69,6 +94,14 @@ provider "snowflake" {
 | error_integration | string | null | Name of the notification integration for error notifications |
 | integration | string | null | Name of the storage integration for auto-ingest |
 | comment | string | null | Description of the pipe |
+| grants | list(object) | [] | List of role grants for the pipe |
+
+### grants Object Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| role_name | string | Name of the role to grant privileges to |
+| privileges | list(string) | List of privileges to grant (MONITOR, OPERATE) |
 
 ## Outputs
 
@@ -78,6 +111,7 @@ provider "snowflake" {
 | pipe_fully_qualified_names | The fully qualified names of the pipes |
 | pipe_notification_channels | The notification channels for the pipes |
 | pipe_owners | The owners of the pipes |
+| pipe_grants | All pipe grant resources |
 
 ## Running This Example
 

--- a/examples/single-pipe/variables.tf
+++ b/examples/single-pipe/variables.tf
@@ -17,6 +17,10 @@ variable "pipe_configs" {
     error_integration = optional(string, null)
     integration       = optional(string, null)
     comment           = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -21,3 +21,32 @@ resource "snowflake_pipe" "this" {
   integration       = each.value.integration
   comment           = each.value.comment
 }
+
+# Flatten grants for all pipes into a single map for iteration
+locals {
+  pipe_grants = flatten([
+    for pipe_key, pipe in var.pipe_configs : [
+      for grant in pipe.grants : {
+        pipe_key   = pipe_key
+        role_name  = grant.role_name
+        privileges = grant.privileges
+      }
+    ]
+  ])
+
+  pipe_grants_map = {
+    for grant in local.pipe_grants :
+    "${grant.pipe_key}_${grant.role_name}" => grant
+  }
+}
+
+resource "snowflake_grant_privileges_to_account_role" "pipe_grants" {
+  for_each = local.pipe_grants_map
+
+  privileges        = each.value.privileges
+  account_role_name = each.value.role_name
+  on_schema_object {
+    object_type = "PIPE"
+    object_name = snowflake_pipe.this[each.value.pipe_key].fully_qualified_name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,3 +31,8 @@ output "pipes" {
   description = "All pipe resources."
   value       = snowflake_pipe.this
 }
+
+output "pipe_grants" {
+  description = "All pipe grant resources."
+  value       = snowflake_grant_privileges_to_account_role.pipe_grants
+}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -203,3 +203,68 @@ func mustEnv(t *testing.T, key string) string {
 func escapeLike(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
 }
+
+func createTestRole(t *testing.T, db *sql.DB, roleName string) {
+	t.Helper()
+	_, err := db.Exec(fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", roleName))
+	require.NoError(t, err, "Failed to create test role")
+}
+
+func dropTestRole(t *testing.T, db *sql.DB, roleName string) {
+	t.Helper()
+	_, err := db.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %s", roleName))
+	require.NoError(t, err, "Failed to drop test role")
+}
+
+func roleHasPipePrivilege(t *testing.T, db *sql.DB, roleName, database, schema, pipeName, privilege string) bool {
+	t.Helper()
+
+	q := fmt.Sprintf("SHOW GRANTS ON PIPE %s.%s.%s", database, schema, pipeName)
+	rows, err := db.Query(q)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	require.NoError(t, err)
+
+	// Find column indices for privilege and grantee_name
+	privIdx, granteeIdx := -1, -1
+	for i, col := range cols {
+		switch col {
+		case "privilege":
+			privIdx = i
+		case "grantee_name":
+			granteeIdx = i
+		}
+	}
+
+	for rows.Next() {
+		values := make([]interface{}, len(cols))
+		valuePtrs := make([]interface{}, len(cols))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		err = rows.Scan(valuePtrs...)
+		require.NoError(t, err)
+
+		getString := func(idx int) string {
+			if idx == -1 || values[idx] == nil {
+				return ""
+			}
+			if s, ok := values[idx].(string); ok {
+				return s
+			}
+			if b, ok := values[idx].([]byte); ok {
+				return string(b)
+			}
+			return fmt.Sprintf("%v", values[idx])
+		}
+
+		if strings.EqualFold(getString(granteeIdx), roleName) && strings.EqualFold(getString(privIdx), privilege) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/test/multiple_pipes_test.go
+++ b/test/multiple_pipes_test.go
@@ -48,6 +48,7 @@ func TestMultiplePipes(t *testing.T) {
 			"copy_statement": fmt.Sprintf("COPY INTO %s.%s.ORDERS FROM @%s.%s.ORDERS_STAGE FILE_FORMAT = (TYPE = CSV)", dbName, schemaName, dbName, schemaName),
 			"auto_ingest":    false,
 			"comment":        "Terratest orders pipe",
+			"grants":         []interface{}{},
 		},
 		"customers_pipe": map[string]interface{}{
 			"database":       dbName,
@@ -56,6 +57,7 @@ func TestMultiplePipes(t *testing.T) {
 			"copy_statement": fmt.Sprintf("COPY INTO %s.%s.CUSTOMERS FROM @%s.%s.CUSTOMERS_STAGE FILE_FORMAT = (TYPE = CSV)", dbName, schemaName, dbName, schemaName),
 			"auto_ingest":    false,
 			"comment":        "Terratest customers pipe",
+			"grants":         []interface{}{},
 		},
 		"events_pipe": map[string]interface{}{
 			"database":       dbName,
@@ -64,6 +66,7 @@ func TestMultiplePipes(t *testing.T) {
 			"copy_statement": fmt.Sprintf("COPY INTO %s.%s.EVENTS FROM @%s.%s.EVENTS_STAGE FILE_FORMAT = (TYPE = CSV)", dbName, schemaName, dbName, schemaName),
 			"auto_ingest":    false,
 			"comment":        "Terratest events pipe",
+			"grants":         []interface{}{},
 		},
 	}
 

--- a/test/pipe_grants_test.go
+++ b/test/pipe_grants_test.go
@@ -1,4 +1,4 @@
-// File: test/single_pipe_test.go
+// File: test/pipe_grants_test.go
 package test
 
 import (
@@ -13,9 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSinglePipe tests creating a single pipe via the module
-// Note: This test requires an external stage. Internal stages do not support pipes.
-func TestSinglePipe(t *testing.T) {
+// TestPipeWithGrants tests creating a pipe with role grants
+func TestPipeWithGrants(t *testing.T) {
 	t.Parallel()
 
 	retrySleep := 5 * time.Second
@@ -25,21 +24,20 @@ func TestSinglePipe(t *testing.T) {
 	tableName := "TEST_TABLE"
 	stageName := "TEST_STAGE"
 	pipeName := fmt.Sprintf("TT_PIPE_%s", unique)
+	roleName := fmt.Sprintf("TT_ROLE_%s", unique)
 
-	// Setup: Create database, schema, table, and external stage
+	// Setup: Create database, schema, table, external stage, and role
 	db := openSnowflake(t)
 	createTestDatabase(t, db, dbName)
 	createTestSchema(t, db, dbName, schemaName)
 	createTestTable(t, db, dbName, schemaName, tableName)
-	
-	// Create an external stage using a public S3 bucket for testing
-	// This uses Snowflake's sample data bucket which is publicly accessible
 	createExternalStage(t, db, dbName, schemaName, stageName)
+	createTestRole(t, db, roleName)
 	_ = db.Close()
 
 	tfDir := "../examples/single-pipe"
 
-	copyStatement := fmt.Sprintf("COPY INTO %s.%s.%s FROM @%s.%s.%s FILE_FORMAT = (TYPE = CSV)", 
+	copyStatement := fmt.Sprintf("COPY INTO %s.%s.%s FROM @%s.%s.%s FILE_FORMAT = (TYPE = CSV)",
 		dbName, schemaName, tableName, dbName, schemaName, stageName)
 
 	pipeConfigs := map[string]interface{}{
@@ -49,8 +47,13 @@ func TestSinglePipe(t *testing.T) {
 			"name":           pipeName,
 			"copy_statement": copyStatement,
 			"auto_ingest":    false,
-			"comment":        "Terratest single pipe test",
-			"grants":         []interface{}{},
+			"comment":        "Terratest pipe with grants test",
+			"grants": []interface{}{
+				map[string]interface{}{
+					"role_name":  roleName,
+					"privileges": []interface{}{"MONITOR", "OPERATE"},
+				},
+			},
 		},
 	}
 
@@ -69,9 +72,10 @@ func TestSinglePipe(t *testing.T) {
 
 	defer func() {
 		terraform.Destroy(t, tfOptions)
-		// Cleanup: Drop test database
+		// Cleanup: Drop test database and role
 		db := openSnowflake(t)
 		dropTestDatabase(t, db, dbName)
+		dropTestRole(t, db, roleName)
 		_ = db.Close()
 	}()
 
@@ -82,12 +86,14 @@ func TestSinglePipe(t *testing.T) {
 	db = openSnowflake(t)
 	defer func() { _ = db.Close() }()
 
+	// Verify pipe exists
 	exists := pipeExists(t, db, dbName, schemaName, pipeName)
 	require.True(t, exists, "Expected pipe %q to exist in Snowflake", pipeName)
 
-	props := fetchPipeProps(t, db, dbName, schemaName, pipeName)
-	require.Equal(t, pipeName, props.Name)
-	require.Equal(t, dbName, props.DatabaseName)
-	require.Equal(t, schemaName, props.SchemaName)
-	require.Contains(t, props.Comment, "Terratest single pipe test")
+	// Verify grants exist
+	hasMonitor := roleHasPipePrivilege(t, db, roleName, dbName, schemaName, pipeName, "MONITOR")
+	require.True(t, hasMonitor, "Expected role %q to have MONITOR privilege on pipe %q", roleName, pipeName)
+
+	hasOperate := roleHasPipePrivilege(t, db, roleName, dbName, schemaName, pipeName, "OPERATE")
+	require.True(t, hasOperate, "Expected role %q to have OPERATE privilege on pipe %q", roleName, pipeName)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,10 @@ variable "pipe_configs" {
     error_integration = optional(string, null)
     integration       = optional(string, null)
     comment           = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {}
 


### PR DESCRIPTION
This pull request adds support for role-based grants on Snowflake pipes, allowing users to specify which roles should receive which privileges (such as MONITOR and OPERATE) on each pipe. The change is fully documented in the README and changelog, includes updates to module variables and outputs, and is covered by new and updated Terratest integration tests.

**New Role Grants Feature:**

- Adds an optional `grants` attribute to the `pipe_configs` variable, enabling assignment of privileges to specific roles for each pipe. This is implemented in the main module code and surfaced as a new output (`pipe_grants`). [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR24-R52) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR22-R25) [[3]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R34-R38)
- Updates documentation and examples (`README.md`, `examples/single-pipe/README.md`, `examples/multiple-pipes/README.md`) to describe the new `grants` attribute, its structure, and usage for both single and multiple pipe scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R126) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R176) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R187) [[5]](diffhunk://#diff-511ecfdf7e0b93d21b36a7c0e61f514941e2853eafcef1c078091f5e17ec0c52R27-R32) [[6]](diffhunk://#diff-511ecfdf7e0b93d21b36a7c0e61f514941e2853eafcef1c078091f5e17ec0c52R42-R47) [[7]](diffhunk://#diff-511ecfdf7e0b93d21b36a7c0e61f514941e2853eafcef1c078091f5e17ec0c52R102-R109) [[8]](diffhunk://#diff-511ecfdf7e0b93d21b36a7c0e61f514941e2853eafcef1c078091f5e17ec0c52R120) [[9]](diffhunk://#diff-f612b7e844c195366ff716ffb235e43e4520ad18493e57b64187817ef862fdcbR24-R48) [[10]](diffhunk://#diff-f612b7e844c195366ff716ffb235e43e4520ad18493e57b64187817ef862fdcbR97-R104) [[11]](diffhunk://#diff-f612b7e844c195366ff716ffb235e43e4520ad18493e57b64187817ef862fdcbR114)

**Testing Improvements:**

- Adds a new integration test (`test/pipe_grants_test.go`) to verify that role-based grants are correctly applied to pipes, including helper functions for creating and checking roles and privileges. [[1]](diffhunk://#diff-d40ae82a067de74f25ca4dd78e9c743bc30f4fd9af9d3391201f6b192b7f3749R1-R99) [[2]](diffhunk://#diff-872d6ed82369c08df0d5afb822e8bd0c6b2ab463e4738261a2731a18df9423d8R206-R270)
- Updates variables and test fixtures to include the `grants` attribute, ensuring backward compatibility and comprehensive test coverage. [[1]](diffhunk://#diff-3b08da177d718a8e0d37ffebf07d2228a0337f0b6b35e998b8b432c7ecfcc16bR20-R23) [[2]](diffhunk://#diff-0d0ebd87c09d9b31437671c4fc79083dc736f13c793663685e99db114b3f91c3R20-R23) [[3]](diffhunk://#diff-2e5755bc1f6388ced8da8c6980209fb1bf2cc6cdd06edc8ba4d8f6fbe8cae6c4R51) [[4]](diffhunk://#diff-2e5755bc1f6388ced8da8c6980209fb1bf2cc6cdd06edc8ba4d8f6fbe8cae6c4R60) [[5]](diffhunk://#diff-2e5755bc1f6388ced8da8c6980209fb1bf2cc6cdd06edc8ba4d8f6fbe8cae6c4R69) [[6]](diffhunk://#diff-615379685b6416ebb571b2254ffaa2034c41a59947d76919d685baed5d35c43cR53)

**Documentation and Changelog:**

- Updates `CHANGELOG.md` to reflect the addition of the role-based grants feature and other minor documentation tasks. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R6) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R25)

These changes make it easier to manage fine-grained access control on Snowflake pipes directly from Terraform.